### PR TITLE
Fix list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
The space between tag_name and the version has been removed which broke
the grep and sed commands. This commit removes the space and makes
list-all work again.