### PR TITLE
Fix error handling in the install script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-18.04, macOS-latest]
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Checkout asdf project
+      run: git clone https://github.com/asdf-vm/asdf.git
+
+    - name: Test kubectl plugin
+      run: |
+        source asdf/asdf.sh
+        asdf plugin-test kubectl https://github.com/${GITHUB_REPOSITORY}.git
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-script: asdf plugin-test kubectl https://github.com/Banno/asdf-kubectl.git
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ asdf plugin-add kubectl https://github.com/Banno/asdf-kubectl.git
 
 ## Use
 
-Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of HashiCorp tools.
+Check out the [asdf documentation](https://asdf-vm.com/#/core-manage-versions?id=install-version) for instructions on how to install and manage versions of Kubectl.

--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_kubectl() {
 
   local bin_path="${bin_install_path}/kubectl"
   echo "Downloading kubectl from ${download_url}"
-  if curl -fs "$download_url" -o "$bin_path"; then
+  if curl -s "$download_url" -o "$bin_path"; then
     chmod +x $bin_path
   else
     exit 1

--- a/bin/install
+++ b/bin/install
@@ -19,8 +19,11 @@ install_kubectl() {
 
   local bin_path="${bin_install_path}/kubectl"
   echo "Downloading kubectl from ${download_url}"
-  curl -s "$download_url" -o "$bin_path"
-  chmod +x $bin_path
+  if curl -fs "$download_url" -o "$bin_path"; then
+    chmod +x $bin_path
+  else
+    exit 1
+  fi
 }
 
 get_arch() {

--- a/bin/install
+++ b/bin/install
@@ -4,7 +4,6 @@ set -e
 set -o pipefail
 
 ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
-TMPDIR=${TMPDIR:-/tmp}
 [ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
 [ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
 


### PR DESCRIPTION
This PR adds few non-breakings modifications to the plugin:
* Add error handling for downloading kubectl in the `install` script, fix #1 
* Remove unused code from the install script
* Update README