### PR TITLE
Increase number of releases fetched in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/kubernetes/kubernetes/releases
+releases_path="https://api.github.com/repos/kubernetes/kubernetes/releases?per_page=100"
 cmd="curl -s"
 if [ -n "$OAUTH_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"


### PR DESCRIPTION
The github API default for listing releases is 30. 
Increase the limit to 100 (the max), so that we get more releases displayed.