### PR TITLE
Show all releases on github

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 
-set \
-  -o pipefail \
-  -o errexit
-
-releases_path="https://api.github.com/repos/kubernetes/kubernetes/releases?per_page=100"
-auth_header=""
-if [ -n "$ASDF_GITHUB_TOKEN" ]; then
-  auth_header="-H \"Authorization: token $ASDF_GITHUB_TOKEN\""
-elif [ -n "$OAUTH" ]; then
-  auth_header="-H \"Authorization: token ${OAUTH_TOKEN}\""
-fi
+set -euo pipefail
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
@@ -18,6 +8,11 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval curl -s ${auth_header} ${releases_path} | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
-echo $versions
+list_all_versions() {
+  git ls-remote --tags --refs https://github.com/kubernetes/kubernetes.git |
+    grep -o 'refs/tags/.*' |
+    cut -d/ -f3- |
+    sed 's/^v//'
+}
+
+list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
Instead of only showing the last 100 releases, use github paging
API to fetch all github releases metadata.