### PR TITLE
fix(install): fail on server errors

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_kubectl() {
 
   local bin_path="${bin_install_path}/kubectl"
   echo "Downloading kubectl from ${download_url}"
-  if curl -s "$download_url" -o "$bin_path"; then
+  if curl -sf "$download_url" -o "$bin_path"; then
     chmod +x $bin_path
   else
     exit 1


### PR DESCRIPTION
Fail on server errors to ensure that script fails when binaries do not exist (i.e. return 404)


For example attempting to retrieve a non-existent binary for [v1.20.1](https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/darwin/arm64/kubectl) executes with a return code of 0, however the response HTTP status is a 404 with the following payload:
```xml
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.20.1/bin/darwin/arm64/kubectl</Details></Error>* 
```

The payload is then erroneously used as the kubectl binary.
