### PR TITLE
Switch URL to new download URL on k8s site

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,7 @@ get_cpu() {
 get_download_url() {
   local version="$1"
   local platform="$(get_arch)"
-  echo "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/${platform}/$(get_cpu)/kubectl"
+  echo "https://dl.k8s.io/release/v${version}/bin/${platform}/$(get_cpu)/kubectl"
 }
 
 install_kubectl $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
Needed this new m1 macs https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/
I am guessing this change works, my local curl seems to be fine.