### PR TITLE
Add ability to override arch with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ asdf plugin-add kubectl https://github.com/asdf-community/asdf-kubectl.git
 ## Use
 
 Check out the [asdf documentation](https://asdf-vm.com/#/core-manage-versions?id=install-version) for instructions on how to install and manage versions of Kubectl.
+
+## Architecture Override
+The `ASDF_KUBECTL_OVERWRITE_ARCH` variable can be used to override the architecture that is used for determining which `kubectl` build to download. The primary use case is when attempting to install an older version of `kubectl` for use on an Apple M1 computer as `kubectl` was not built for ARM at the time.
+
+### Without `ASDF_KUBECTL_OVERWRITE_ARCH`:
+
+```
+% asdf install kubectl 1.18.17
+Downloading kubectl from https://storage.googleapis.com/kubernetes-release/release/v1.18.17/bin/darwin/arm64/kubectl
+```
+
+### With `ASDF_KUBECTL_OVERWRITE_ARCH`:
+
+```
+% ASDF_KUBECTL_OVERWRITE_ARCH=amd64 asdf install kubectl 1.18.17
+Downloading kubectl from https://storage.googleapis.com/kubernetes-release/release/v1.18.17/bin/darwin/amd64/kubectl
+```
+

--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ get_arch() {
 
 get_cpu() {
   local machine_hardware_name
-  machine_hardware_name="$(uname -m)"
+  machine_hardware_name=${ASDF_KUBECTL_OVERWRITE_ARCH:-"$(uname -m)"}
 
   case "$machine_hardware_name" in
     'x86_64') local cpu_type="amd64";;


### PR DESCRIPTION
Workaround for https://github.com/asdf-community/asdf-kubectl/issues/19

Inspired by the way the [golang](https://github.com/kennyp/asdf-golang/blob/master/bin/download#L10:L25) plugin handles this, this PR will allow the user to set an environment variable `ASDF_KUBECTL_OVERWRITE_ARCH` and specify an alternative architecture to download the binary from.

Mac users on M1 laptops will have issues downloading older versions of `kubectl` that do not have `arm64` builds. Their installations right now silently fail and there is no way to configure `asdf` to download the `amd64` build instead.

## Demonstration (M1 Max):

```
% uname -m
arm64

% kubectl version
No preset version installed for command kubectl
Please install a version by running one of the following:

asdf install kubectl 1.18.17

% asdf install kubectl 1.18.17

Downloading kubectl from https://storage.googleapis.com/kubernetes-release/release/v1.18.17/bin/darwin/arm64/kubectl

% kubectl version
No preset version installed for command kubectl

% ASDF_KUBECTL_OVERWRITE_ARCH=amd64 asdf install kubectl 1.18.17
Downloading kubectl from https://storage.googleapis.com/kubernetes-release/release/v1.18.17/bin/darwin/amd64/kubectl

% kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.17", GitCommit:"68b4e26caf6ede7af577db4af62fb405b4dd47e6", GitTreeState:"clean", BuildDate:"2021-03-18T01:02:41Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"darwin/amd64"}
```