### PR TITLE
Added latest-stable direct command, to speed up retrieval of just the latest kubectl version

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -L -s https://dl.k8s.io/release/stable.txt | cut -c 2- -


### PR DESCRIPTION
While the actual speedup depends on the speed of client system and of local Internet connection, on my system (macOS, VDSL 55Mbit/s DL) this allows to move from:

```
❯ /usr/bin/time -h asdf latest kubectl
1.23.4
	0.82s real		0.11s user		0.11s sys
```

to:

```
❯ /usr/bin/time -h asdf latest kubectl
1.23.4
	0.62s real		0.04s user		0.03s sys
```

Implementation of `latest-stable` script is totally optional, of course, but might beneficial in cases like these, since we are expecting a ton of kubectl versions appearing as time goes by.

Inside the script I'm using the recommended official endpoint to get the latest stable version of kubectl, which is `https://dl.k8s.io/release/stable.txt`.