### PR TITLE
fix: fix list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -9,10 +9,14 @@ function sort_versions() {
 }
 
 list_all_versions() {
-  git ls-remote --tags --refs https://github.com/kubernetes/kubernetes.git |
+  git ls-remote --tags --refs https://github.com/bitnami-labs/sealed-secrets.git |
+    # skip helm tags
+    grep -v helm |
+    # skip wrong tags in the repo
+    grep -v sealed-secrets |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
-    sed 's/^v//'
+    sed 's/^v//' | sort_versions
 }
 
 list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
I'm having the same issue when trying to use this:

```
rtx kubeseal@latest installing
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
rtx kubeseal@latest Downloading kubeseal from https://github.com/bitnami-labs/sealed-secrets/releases/download/vlatest/kubeseal-latest-linux-amd64.tar.gz to /tmp/kubeseal_O7vf2W/kubeseal-latest-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Error: 
   0: ~/.local/share/rtx/plugins/kubeseal/bin/install exited with non-zero status: exit code 22

Location:
   src/plugins/script_manager.rs:237

Version:
   1.22.7 linux-x64 (built 2023-03-10)

Suggestion: Run with RTX_DEBUG=1 for more information.

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```